### PR TITLE
[fix] make nvm.env exit with error when VERBOSE is unset

### DIFF
--- a/utils/lib_nvm.sh
+++ b/utils/lib_nvm.sh
@@ -27,6 +27,7 @@ nvm.env() {
     source "${NVM_DIR}/nvm.sh"
     source "${NVM_DIR}/bash_completion"
     [ "$VERBOSE" = "1" ] && info_msg "sourced NVM environment from ${NVM_DIR}"
+    return 0
 }
 
 nvm.is_installed() {


### PR DESCRIPTION
Fix `make nvm.env` exit with error when VERBOSE is unset

    $ make nvm.install
    INFO:  install (update) NVM at /800GBPCIex4/share/SearXNG/.nvm
    INFO:  already cloned at: /800GBPCIex4/share/SearXNG/.nvm
      || Fetching origin
    INFO:  checkout v0.39.1
      || HEAD is now at 9600617 v0.39.1
    make: *** [Makefile:96: nvm.install] Error 1

Without this fix we need to set VERBOSE environment to avoid the 'Error 1':

    $ VERBOSE=0 make nvm.install

Signed-off-by: Markus Heiser <markus.heiser@darmarit.de>