### PR TITLE
[mod] Sepiasearch (Video): re-engineered & upgrade to data_type: traits_v1

### DIFF
--- a/searx/data/engine_traits.json
+++ b/searx/data/engine_traits.json
@@ -3299,6 +3299,34 @@
     },
     "supported_languages": {}
   },
+  "sepiasearch": {
+    "all_locale": null,
+    "custom": {},
+    "data_type": "traits_v1",
+    "languages": {
+      "ca": "ca",
+      "cs": "cs",
+      "de": "de",
+      "el": "el",
+      "en": "en",
+      "eo": "eo",
+      "es": "es",
+      "eu": "eu",
+      "fi": "fi",
+      "fr": "fr",
+      "gd": "gd",
+      "it": "it",
+      "ja": "ja",
+      "nl": "nl",
+      "pl": "pl",
+      "pt": "pt",
+      "ru": "ru",
+      "sv": "sv",
+      "zh": "zh"
+    },
+    "regions": {},
+    "supported_languages": {}
+  },
   "startpage": {
     "all_locale": null,
     "custom": {},


### PR DESCRIPTION
## What does this PR do?

- fetch_traits() Sepiasearch and Peertube are using identical languages. Replace module's dictionary `supported_languages` by `engine.traits.languages` (data_type: `traits_v1`).
- fixed code to pass pylint
- request(): add argument boostLanguages
- response(): add metadata from channel name, host & tags
