### PR TITLE
[mod] remove obsolete EngineTraits.supported_languages

### DIFF
--- a/searx/autocomplete.py
+++ b/searx/autocomplete.py
@@ -18,9 +18,6 @@ from searx.engines import (
 from searx.network import get as http_get
 from searx.exceptions import SearxEngineResponseException
 
-# a fetch_supported_languages() for XPath engines isn't available right now
-# _brave = ENGINES_LANGUAGES['brave'].keys()
-
 
 def get(*args, **kwargs):
     if 'timeout' not in kwargs:
@@ -224,14 +221,6 @@ def search_autocomplete(backend_name, query, sxng_locale):
     backend = backends.get(backend_name)
     if backend is None:
         return []
-
-    if engines[backend_name].traits.data_type != "traits_v1":
-        # vintage / deprecated
-        if not sxng_locale or sxng_locale == 'all':
-            sxng_locale = 'en'
-        else:
-            sxng_locale = sxng_locale.split('-')[0]
-
     try:
         return backend(query, sxng_locale)
     except (HTTPError, SearxEngineResponseException):

--- a/searx/data/engine_traits.json
+++ b/searx/data/engine_traits.json
@@ -49,8 +49,7 @@
       "uk": "\u0423\u043a\u0440\u0430\u0457\u043d\u0441\u044c\u043a\u0430",
       "zh": "\u4e2d\u6587\uff08\u7e41\u9ad4\uff09"
     },
-    "regions": {},
-    "supported_languages": {}
+    "regions": {}
   },
   "bing": {
     "all_locale": null,
@@ -146,8 +145,7 @@
       "zh-CN": "zh-CN",
       "zh-HK": "zh-HK",
       "zh-TW": "zh-TW"
-    },
-    "supported_languages": {}
+    }
   },
   "bing images": {
     "all_locale": null,
@@ -243,8 +241,7 @@
       "zh-CN": "zh-CN",
       "zh-HK": "zh-HK",
       "zh-TW": "zh-TW"
-    },
-    "supported_languages": {}
+    }
   },
   "bing news": {
     "all_locale": "en-WW",
@@ -316,8 +313,7 @@
       "it-IT": "it-IT",
       "pt-BR": "pt-BR",
       "zh-CN": "zh-CN"
-    },
-    "supported_languages": {}
+    }
   },
   "bing videos": {
     "all_locale": null,
@@ -413,8 +409,7 @@
       "zh-CN": "zh-CN",
       "zh-HK": "zh-HK",
       "zh-TW": "zh-TW"
-    },
-    "supported_languages": {}
+    }
   },
   "dailymotion": {
     "all_locale": null,
@@ -491,8 +486,7 @@
       "vi-VN": "vi_VN",
       "zh-CN": "zh_CN",
       "zh-TW": "zh_TW"
-    },
-    "supported_languages": {}
+    }
   },
   "duckduckgo": {
     "all_locale": "wt-wt",
@@ -656,8 +650,7 @@
       "zh-CN": "cn-zh",
       "zh-HK": "hk-tzh",
       "zh-TW": "tw-tzh"
-    },
-    "supported_languages": {}
+    }
   },
   "duckduckgo images": {
     "all_locale": "wt-wt",
@@ -821,8 +814,7 @@
       "zh-CN": "cn-zh",
       "zh-HK": "hk-tzh",
       "zh-TW": "tw-tzh"
-    },
-    "supported_languages": {}
+    }
   },
   "duckduckgo weather": {
     "all_locale": "wt-wt",
@@ -986,8 +978,7 @@
       "zh-CN": "cn-zh",
       "zh-HK": "hk-tzh",
       "zh-TW": "tw-tzh"
-    },
-    "supported_languages": {}
+    }
   },
   "google": {
     "all_locale": "ZZ",
@@ -1439,8 +1430,7 @@
       "zh-HK": "HK",
       "zh-SG": "SG",
       "zh-TW": "TW"
-    },
-    "supported_languages": {}
+    }
   },
   "google images": {
     "all_locale": "ZZ",
@@ -1892,8 +1882,7 @@
       "zh-HK": "HK",
       "zh-SG": "SG",
       "zh-TW": "TW"
-    },
-    "supported_languages": {}
+    }
   },
   "google news": {
     "all_locale": "ZZ",
@@ -2238,8 +2227,7 @@
       "zh-HK": "HK",
       "zh-SG": "SG",
       "zh-TW": "TW"
-    },
-    "supported_languages": {}
+    }
   },
   "google scholar": {
     "all_locale": "ZZ",
@@ -2691,8 +2679,7 @@
       "zh-HK": "HK",
       "zh-SG": "SG",
       "zh-TW": "TW"
-    },
-    "supported_languages": {}
+    }
   },
   "google videos": {
     "all_locale": "ZZ",
@@ -3144,8 +3131,7 @@
       "zh-HK": "HK",
       "zh-SG": "SG",
       "zh-TW": "TW"
-    },
-    "supported_languages": {}
+    }
   },
   "peertube": {
     "all_locale": null,
@@ -3174,8 +3160,7 @@
       "zh_Hans": "zh",
       "zh_Hant": "zh"
     },
-    "regions": {},
-    "supported_languages": {}
+    "regions": {}
   },
   "qwant": {
     "all_locale": null,
@@ -3222,8 +3207,7 @@
       "th-TH": "th_TH",
       "zh-CN": "zh_CN",
       "zh-HK": "zh_HK"
-    },
-    "supported_languages": {}
+    }
   },
   "qwant images": {
     "all_locale": null,
@@ -3270,8 +3254,7 @@
       "th-TH": "th_TH",
       "zh-CN": "zh_CN",
       "zh-HK": "zh_HK"
-    },
-    "supported_languages": {}
+    }
   },
   "qwant news": {
     "all_locale": null,
@@ -3303,8 +3286,7 @@
       "nl-BE": "nl_BE",
       "nl-NL": "nl_NL",
       "pt-PT": "pt_PT"
-    },
-    "supported_languages": {}
+    }
   },
   "qwant videos": {
     "all_locale": null,
@@ -3351,8 +3333,7 @@
       "th-TH": "th_TH",
       "zh-CN": "zh_CN",
       "zh-HK": "zh_HK"
-    },
-    "supported_languages": {}
+    }
   },
   "sepiasearch": {
     "all_locale": null,
@@ -3381,8 +3362,7 @@
       "zh_Hans": "zh",
       "zh_Hant": "zh"
     },
-    "regions": {},
-    "supported_languages": {}
+    "regions": {}
   },
   "startpage": {
     "all_locale": null,
@@ -3521,8 +3501,7 @@
       "zh-CN": "zh-CN_CN",
       "zh-HK": "zh-TW_HK",
       "zh-TW": "zh-TW_TW"
-    },
-    "supported_languages": {}
+    }
   },
   "wikidata": {
     "all_locale": null,
@@ -3610,8 +3589,7 @@
       "zh": "zh",
       "zh_Hant": "zh-classical"
     },
-    "regions": {},
-    "supported_languages": {}
+    "regions": {}
   },
   "wikipedia": {
     "all_locale": null,
@@ -3779,8 +3757,7 @@
       "zh_Hans": "zh",
       "zh_Hant": "zh-classical"
     },
-    "regions": {},
-    "supported_languages": {}
+    "regions": {}
   },
   "yahoo": {
     "all_locale": "any",
@@ -3820,7 +3797,6 @@
       "zh_Hans": "zh_chs",
       "zh_Hant": "zh_cht"
     },
-    "regions": {},
-    "supported_languages": {}
+    "regions": {}
   }
 }

--- a/searx/enginelib/__init__.py
+++ b/searx/enginelib/__init__.py
@@ -134,10 +134,3 @@ class Engine:  # pylint: disable=too-few-public-methods
           require_api_key: true
           results: HTML
     """
-
-    # deprecated properties
-
-    _fetch_supported_languages: Callable  # deprecated use fetch_traits
-    supported_languages: Union[List[str], Dict[str, str]]  # deprecated use traits
-    language_aliases: Dict[str, str]  # deprecated not needed when using triats
-    supported_languages_url: str  # deprecated not needed when using triats

--- a/searx/engines/__init__.py
+++ b/searx/engines/__init__.py
@@ -43,8 +43,6 @@ ENGINE_DEFAULT_ARGS = {
     "send_accept_language_header": False,
     "tokens": [],
     "about": {},
-    "supported_languages": [],  # deprecated use traits
-    "language_aliases": {},  # deprecated not needed when using traits
 }
 # set automatically when an engine does not have any tab category
 OTHER_CATEGORY = 'other'

--- a/searx/engines/gentoo.py
+++ b/searx/engines/gentoo.py
@@ -25,6 +25,7 @@ base_url = 'https://wiki.gentoo.org'
 # xpath queries
 xpath_results = '//ul[@class="mw-search-results"]/li'
 xpath_link = './/div[@class="mw-search-result-heading"]/a'
+xpath_content = './/div[@class="searchresult"]'
 
 
 # cut 'en' from 'en-US', 'de' from 'de-CH', and so on
@@ -77,8 +78,6 @@ main_langs = {
     'uk': 'Українська',
     'zh': '简体中文',
 }
-supported_languages = dict(lang_urls, **main_langs)
-
 
 # do search-request
 def request(query, params):
@@ -118,7 +117,8 @@ def response(resp):
         link = result.xpath(xpath_link)[0]
         href = urljoin(base_url, link.attrib.get('href'))
         title = extract_text(link)
+        content = extract_text(result.xpath(xpath_content))
 
-        results.append({'url': href, 'title': title})
+        results.append({'url': href, 'title': title, 'content': content})
 
     return results

--- a/searx/search/processors/online.py
+++ b/searx/search/processors/online.py
@@ -220,7 +220,7 @@ class OnlineProcessor(EngineProcessor):
                 'test': ['unique_results'],
             }
 
-        if getattr(self.engine, 'supported_languages', []):
+        if getattr(self.engine, 'traits', False):
             tests['lang_fr'] = {
                 'matrix': {'query': 'paris', 'lang': 'fr'},
                 'result_container': ['not_empty', ('has_language', 'fr')],

--- a/searx/webapp.py
+++ b/searx/webapp.py
@@ -1307,11 +1307,6 @@ def config():
             continue
 
         _languages = engine.traits.languages.keys()
-        if engine.traits.data_type == 'supported_languages':  # vintage / deprecated
-            _languages = engine.traits.supported_languages
-            if isinstance(_languages, dict):
-                _languages = _languages.keys()
-
         _engines.append(
             {
                 'name': name,


### PR DESCRIPTION
All engines has been migrated from ``supported_languages`` to the ``fetch_traits`` concept.  There is no longer a need for the obsolete code that implements the ``supported_languages`` concept.
